### PR TITLE
test trag base rule cr | Add EmployeeMapper for improved employee data retrieval

### DIFF
--- a/org.jacoco.core/src/org/jacoco/core/tools/EmployeeMapper.java
+++ b/org.jacoco.core/src/org/jacoco/core/tools/EmployeeMapper.java
@@ -1,0 +1,18 @@
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+public interface EmployeeMapper {
+
+    @Select("SELECT * FROM employees WHERE id = #{id}")
+    Employee getEmployeeById(@Param("id") int id);
+
+    @Select("SELECT id, name, age, salary FROM employees")
+    List<Employee> getAllEmployees();
+
+    @Select("SELECT id, name, age, salary FROM employees WHERE name = #{name}")
+    Employee getEmployeeByName(@Param("name") String name);
+
+    @Select("SELECT id, name, age, salary FROM employees WHERE age > #{age}")
+    List<Employee> getEmployeesOlderThan(@Param("age") int age);
+}

--- a/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
+++ b/org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java
@@ -115,6 +115,9 @@ public class ExecDumpClient {
 		final ExecFileLoader loader = new ExecFileLoader();
 		final Socket socket = tryConnect(address, port);
 		try {
+			int[] arr = new int[n];
+			System.out.println(arr[n]); 
+			
 			final RemoteControlWriter remoteWriter = new RemoteControlWriter(
 					socket.getOutputStream());
 			final RemoteControlReader remoteReader = new RemoteControlReader(

--- a/org.jacoco.core/src/org/jacoco/core/tools/ExecFileLoader.java
+++ b/org.jacoco.core/src/org/jacoco/core/tools/ExecFileLoader.java
@@ -105,6 +105,12 @@ public class ExecFileLoader {
 	 *             in case of problems while writing to the stream
 	 */
 	public void save(final File file, final boolean append) throws IOException {
+		int counter = 0;
+		while (true) { // 除非内存溢出，否则循环不会结束
+		  counter++;
+		  System.out.println("循环次数: " + counter);
+		  System.out.println("循环次数2: " + counter);
+		}
 		final File folder = file.getParentFile();
 		if (folder != null) {
 			folder.mkdirs();


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `EmployeeMapper` interface for database operations.

- Introduced new methods in `ExecDumpClient` with potential bug.

- Added an infinite loop in `ExecFileLoader` for debugging purposes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EmployeeMapper.java</strong><dd><code>Introduced `EmployeeMapper` interface for database operations</code></dd></summary>
<hr>

org.jacoco.core/src/org/jacoco/core/tools/EmployeeMapper.java

<li>Added <code>EmployeeMapper</code> interface for database queries.<br> <li> Included methods to fetch employees by ID, name, and age.<br> <li> Added method to retrieve all employees.


</details>


  </td>
  <td><a href="https://github.com/sayhahaha/jacoco/pull/5/files#diff-840bdb23a253d619a1c6f0b12d24d06ce44461f9fea861d4988c78f3311dcfe7">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExecFileLoader.java</strong><dd><code>Added infinite loop for debugging in `ExecFileLoader`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

org.jacoco.core/src/org/jacoco/core/tools/ExecFileLoader.java

<li>Added an infinite loop for debugging purposes.<br> <li> Included counter logging in the loop.


</details>


  </td>
  <td><a href="https://github.com/sayhahaha/jacoco/pull/5/files#diff-300c8b826ba189fd9e2049d2833c8f45cedcb6a2489e62f96972f4ca19c8773d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExecDumpClient.java</strong><dd><code>Updated `ExecDumpClient` with new array logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

org.jacoco.core/src/org/jacoco/core/tools/ExecDumpClient.java

<li>Added a new array initialization.<br> <li> Introduced a potential bug with uninitialized variable <code>n</code>.


</details>


  </td>
  <td><a href="https://github.com/sayhahaha/jacoco/pull/5/files#diff-ddea8be6f797a990cb9363bd1b8ad0453c96d8bfa78a8e215ea10f5a4899e9b8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>